### PR TITLE
feat: 添加自动发布 workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,62 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main                 # 正式环境
+      - feat-release-flow    # 测试环境
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      created_tag: ${{ steps.create_tag.outputs.tag_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 获取所有历史，用于 git tag 操作
+
+      - name: Get version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(awk '/^\[project\]/,/^\\[.*\]/ { if (/^version\s*=/) print }' pyproject.toml | sed 's/version\s*=\s*["\']\([^"\']*\)["\']/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get latest tag
+        id: get_latest_tag
+        run: |
+          # 获取所有 tag 并按版本排序，取最新的
+          LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST=${LATEST#v}
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        id: version_check
+        run: |
+          python - <<EOF
+          from packaging import version
+          pyproject_ver = "${{ steps.get_version.outputs.version }}"
+          latest_ver = "${{ steps.get_release.outputs.latest }}"
+          should_release = version.parse(pyproject_ver) > version.parse(latest_ver)
+          with open("$GITHUB_OUTPUT", "a") as f:
+              f.write(f"should_release={should_release.lower()}\n")
+          print(f"PyProject version: {pyproject_ver}")
+          print(f"Latest release: {latest_ver}")
+          print(f"Should release: {should_release}")
+          EOF
+
+      - name: Create and push tag
+        id: create_tag
+        if: steps.version_check.outputs.should_release == 'true'
+        run: |
+          TAG_NAME="v${{ steps.get_version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "✓ Created tag: $TAG_NAME"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main                 # 正式环境
-      - feat-release-flow    # 测试环境
 
 permissions:
   contents: write
@@ -137,7 +136,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.auto-tag.outputs.tag_name }}
-          draft: true  # 临时设为 true，测试结束后改回 false
+          draft: false
           prerelease: false
           generate_release_notes: true
           files: |

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,7 +13,9 @@ jobs:
   auto-tag:
     runs-on: ubuntu-latest
     outputs:
-      created_tag: ${{ steps.create_tag.outputs.tag_name }}
+      should_release: ${{ steps.version_check.outputs.should_release }}
+      version: ${{ steps.get_version.outputs.version }}
+      tag_name: ${{ steps.create_tag.outputs.tag_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,3 +62,86 @@ jobs:
           git push origin "$TAG_NAME"
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "✓ Created tag: $TAG_NAME"
+
+  build:
+    needs: auto-tag
+    if: needs.auto-tag.outputs.should_release == 'true'
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [x64]
+        python-version: ['3.11']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          pytest -v --cov=remark --cov-report=term-missing
+
+      - name: Install PyInstaller
+        run: |
+          pip install pyinstaller
+
+      - name: Build executable
+        run: |
+          pyinstaller remark.spec --clean
+
+      - name: Rename executable with version
+        run: |
+          $version = "${{ needs.auto-tag.outputs.version }}"
+          Copy-Item "dist\windows-folder-remark.exe" "dist\windows-folder-remark-$version.exe"
+
+      - name: Generate checksum
+        run: |
+          $version = "${{ needs.auto-tag.outputs.version }}"
+          $file = "dist\windows-folder-remark-$version.exe"
+          certutil -hashfile $file SHA256 > "$file.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-folder-remark-${{ matrix.architecture }}
+          path: |
+            dist/*.exe
+            dist/*.sha256
+
+  release:
+    needs: [auto-tag, build]
+    if: needs.auto-tag.outputs.should_release == 'true'
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.auto-tag.outputs.tag_name }}
+          draft: true  # 临时设为 true，测试结束后改回 false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            artifacts/**/*.exe
+            artifacts/**/*.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get version from pyproject.toml
         id: get_version
         run: |
-          VERSION=$(awk '/^\[project\]/,/^\\[.*\]/ { if (/^version\s*=/) print }' pyproject.toml | sed 's/version\s*=\s*["\']\([^"\']*\)["\']/\1/')
+          VERSION=$(python3 -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get latest tag
@@ -40,12 +40,12 @@ jobs:
           python - <<EOF
           from packaging import version
           pyproject_ver = "${{ steps.get_version.outputs.version }}"
-          latest_ver = "${{ steps.get_release.outputs.latest }}"
+          latest_ver = "${{ steps.get_latest_tag.outputs.latest }}"
           should_release = version.parse(pyproject_ver) > version.parse(latest_ver)
           with open("$GITHUB_OUTPUT", "a") as f:
               f.write(f"should_release={should_release.lower()}\n")
           print(f"PyProject version: {pyproject_ver}")
-          print(f"Latest release: {latest_ver}")
+          print(f"Latest tag: {latest_ver}")
           print(f"Should release: {should_release}")
           EOF
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get version from pyproject.toml
         id: get_version
         run: |
-          VERSION=$(python3 -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get latest tag

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -43,7 +43,7 @@ jobs:
           latest_ver = "${{ steps.get_latest_tag.outputs.latest }}"
           should_release = version.parse(pyproject_ver) > version.parse(latest_ver)
           with open("$GITHUB_OUTPUT", "a") as f:
-              f.write(f"should_release={should_release.lower()}\n")
+              f.write(f"should_release={str(should_release).lower()}\n")
           print(f"PyProject version: {pyproject_ver}")
           print(f"Latest tag: {latest_ver}")
           print(f"Should release: {should_release}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
-          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          draft: true  # 临时设为 true，测试结束后改回 ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: false
           generate_release_notes: true
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
-          draft: true  # 临时设为 true，测试结束后改回 ${{ github.event_name == 'workflow_dispatch' }}
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: false
           generate_release_notes: true
           files: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,10 @@ repos:
     rev: v0.8.4
     hooks:
       - id: ruff
+        types: [python]
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        types: [python]
 
   # Pre-commit hooks for general checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -37,6 +39,7 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
+        types: [python]
         additional_dependencies:
           - types-setuptools
         exclude: ^remark\.py$
@@ -48,6 +51,7 @@ repos:
         name: Run tests
         entry: pytest -v -m "not slow" --cov=remark --cov-report=term-missing
         language: system
+        types: [python]
         stages: [pre-commit, pre-push]
         pass_filenames: false
 
@@ -55,6 +59,7 @@ repos:
         name: Build exe (Windows only)
         entry: bash -c 'if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then pyinstaller remark.spec --clean; else echo "Skip build on non-Windows"; fi'
         language: system
+        files: '^(.*\.py|.*\.spec)$'
         stages: [pre-push]
         pass_filenames: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "windows-folder-remark"
-version = "2.0.2"
+version = "2.0.3"
 description = "Windows 文件夹备注工具"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- 添加自动发布 workflow，在 main 分支 push 时自动检测版本号变化并创建 release
- 优化 pre-commit hooks，仅在相关文件变更时执行

## 主要变更

### 新增文件

- **`.github/workflows/auto-tag.yml`**: 自动发布 workflow
  - 检测 `pyproject.toml` 版本号与最新 tag 比较
  - 版本号更新时自动创建 tag
  - 在同一 workflow 中完成构建和发布（避免 GitHub Actions 限制）

### 修改文件

- **`.pre-commit-config.yaml`**: 优化 hooks 执行条件
  - Python 静态检查（ruff、mypy）仅在 Python 文件变更时执行
  - 测试仅在 Python 文件变更时执行
  - 构建仅在 Python 或 .spec 文件变更时执行

- **`pyproject.toml`**: 版本号更新至 2.0.3

## 使用方式

1. 在分支上更新 `pyproject.toml` 版本号
2. 合并到 main 分支
3. workflow 自动创建 tag 并发布 release

## Test plan

- [x] Workflow 测试通过（draft release 验证）
- [x] Pre-commit hooks 验证通过