### PR TITLE
feat: 支持 --view/--delete/--gui 命令的模糊路径解析

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "windows-folder-remark"
-version = "2.0.4"
+version = "2.0.5"
 description = "Windows 文件夹备注工具"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,6 +1,7 @@
 """CLI 命令单元测试"""
 
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -327,6 +328,84 @@ class TestCLI:
                 cli.run([])
             # sys.exit(1) 会被调用
             assert exc_info.value.code == 1
+
+
+@pytest.mark.unit
+class TestResolvePathAmbiguousArgs:
+    """测试 _resolve_path_from_ambiguous_args 方法"""
+
+    @pytest.fixture(autouse=True)
+    def disable_background_update_check(self, monkeypatch):
+        """禁用后台更新检查，避免 pyfakefs 隔离被后台线程破坏"""
+        monkeypatch.setattr(
+            "remark.cli.commands.CLI._start_update_checker",
+            lambda self: None,
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_valid_folder(self, fs):
+        """测试解析有效文件夹路径"""
+        fs.create_dir("/My Documents/folder")
+        cli = CLI()
+        path = cli._resolve_path_from_ambiguous_args(["My", "Documents", "folder"])
+        assert path is not None
+        assert "My Documents" in path
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_file_rejected(self, fs):
+        """测试拒绝文件路径"""
+        fs.create_file("/file.txt")
+        cli = CLI()
+        with patch("builtins.print"):
+            path = cli._resolve_path_from_ambiguous_args(["file"])
+        assert path is None  # 文件应被拒绝
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_no_candidates(self, fs):
+        """测试无候选路径时返回 None"""
+        cli = CLI()
+        with patch("builtins.print"):
+            path = cli._resolve_path_from_ambiguous_args(["nonexistent"])
+        assert path is None
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_single_candidate(self, fs, monkeypatch, capsys):
+        """测试单个候选路径直接返回"""
+        fs.create_dir("/My Folder")
+        cli = CLI()
+        # Mock input 模拟用户确认
+        monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "y")
+
+        path = cli._resolve_path_from_ambiguous_args(["My", "Folder"])
+        assert path is not None
+        assert "My Folder" in path
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_multiple_candidates_user_cancels(self, fs, monkeypatch):
+        """测试多个候选路径用户取消"""
+        fs.create_dir("/folder1")
+        fs.create_dir("/folder2")
+        cli = CLI()
+        # Mock input 模拟用户选择取消
+        monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "0")
+
+        path = cli._resolve_path_from_ambiguous_args(["folder"])
+        assert path is None
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
+    def test_resolve_path_multiple_candidates_user_selects(self, fs, monkeypatch):
+        """测试多个候选路径用户选择"""
+        # 在同一目录下创建多个同名的文件夹（不同路径）
+        fs.create_dir("/parent1/folder")
+        fs.create_dir("/parent2/folder")
+        cli = CLI()
+        # Mock input 模拟用户选择第一个选项
+        inputs = iter(["1"])
+        monkeypatch.setattr("builtins.input", lambda *args, **kwargs: next(inputs))
+
+        path = cli._resolve_path_from_ambiguous_args(["parent1", "folder"])
+        assert path is not None
+        assert "parent1" in path
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,7 +1,6 @@
 """CLI 命令单元测试"""
 
 import os
-from unittest.mock import patch
 
 import pytest
 
@@ -356,16 +355,14 @@ class TestResolvePathAmbiguousArgs:
         """测试拒绝文件路径"""
         fs.create_file("/file.txt")
         cli = CLI()
-        with patch("builtins.print"):
-            path = cli._resolve_path_from_ambiguous_args(["file"])
+        path = cli._resolve_path_from_ambiguous_args(["file"])
         assert path is None  # 文件应被拒绝
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows only")
     def test_resolve_path_no_candidates(self, fs):
         """测试无候选路径时返回 None"""
         cli = CLI()
-        with patch("builtins.print"):
-            path = cli._resolve_path_from_ambiguous_args(["nonexistent"])
+        path = cli._resolve_path_from_ambiguous_args(["nonexistent"])
         assert path is None
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows only")


### PR DESCRIPTION
## Summary

为 `--view`, `--delete`, `--gui` 命令添加与位置参数相同的模糊路径解析功能，用户可以输入未加引号的含空格路径，程序会自动智能重建完整路径。

## 主要变更

- **CLI 命令处理**: 新增 `_resolve_path_from_ambiguous_args` 方法，复用 `find_candidates` 路径解析逻辑
- **代码重构**: 提取公共的 `_select_from_multiple_candidates` 方法，减少 `_handle_ambiguous_path` 和 `_resolve_path_from_ambiguous_args` 之间的代码重复
- **语法优化**: 使用列表解包语法 `[x, *args]` 替代列表合并 `[x] + args`
- **测试覆盖**: 添加 6 个单元测试用例，覆盖所有场景

## 示例

现在以下命令都支持未加引号的含空格路径：
```bash
remark --view My Documents folder
remark --delete Program Files App
remark --gui C:/My Folder
```

## Test plan

- [x] 单元测试通过（31 个测试全部通过）
- [x] 本地验证通过
- [x] CI/CD 流程通过